### PR TITLE
Change to elixir map to reduce run time in half.

### DIFF
--- a/elixir/lib/map_actor.ex
+++ b/elixir/lib/map_actor.ex
@@ -1,20 +1,18 @@
 defmodule MapActor do
   @pattern ~r/knicks/i
-
+  
   def map(file) do
+    match = @pattern
     #IO.puts "mapping file #{file}"
     File.stream!(file)
-    |> Stream.map(fn line -> String.split(line, "\t") end)
+    |> Stream.filter( fn(line) -> Regex.match?(match,line) end)
     |> Enum.reduce(HashDict.new, &reduce_stream/2)
   end
 
-  def reduce_stream([_, hood, _, message], acc) do
+  def reduce_stream(message, acc) do
+    hood = String.split(message,"\t") |> Enum.at(1)
     hook = String.to_atom(hood)
-    #if String.contains? String.downcase(message), "knicks" do
-    if message =~ @pattern do
-      HashDict.update(acc, hook, 1, &(&1 + 1))
-    else
-      acc
-    end
+    HashDict.update(acc, hook, 1, &(&1 + 1))
   end
+
 end


### PR DESCRIPTION
You're parsing every tweet when there is no need to do so. Moving the filter into the stream and out of the reduce cuts the run time in half on my MacBook Pro. 

start timed run
6.839

