### PR TITLE
Rust 1.2 build fix

### DIFF
--- a/run_rust
+++ b/run_rust
@@ -2,6 +2,9 @@
 
 export TIMEFORMAT=%R
 cd rust
+cargo clean
+cargo update
+cargo build
 cargo build --release
 function mapreduce_regex {
 	echo 'start timed run (regex)'


### PR DESCRIPTION
From best I can tell about the error mentioned in #14, cargo didn't like that we were trying to build a release version of the application prior to building a debug version.  I actually don't know, but that appears to have fixed the issue for rust 1.2.  It may not be necessary, but I also completely removed `~/.cargo` after upgrading to 1.2 just to make sure I was starting with a clean slate.

![image](https://cloud.githubusercontent.com/assets/1804/9637330/55ef6d94-515d-11e5-8b81-f044f69660fc.png)

As an interesting side note, rust 1.2 has a much, much faster regex implementation (from 19.1 seconds in version 1.0 down to 1.7 seconds in version 1.2).

<table>
  <tr>
    <td>Rust w/ Substring</td>
    <td><del>2.4s</del> <ins>2.3s</ins></td>
  </tr>
  <tr>
    <td>Rust w/ Regular Expression</td>
    <td><del>19.1s</del> <ins>1.7s</ins></td>
  </tr>
</table>