### PR TITLE
golang: make run time estimate more accurate.

### DIFF
--- a/run_go
+++ b/run_go
@@ -1,7 +1,6 @@
 #!/bin/bash
 
+(cd golang && go build search.go)
+
 export TIMEFORMAT=%R
-time go run golang/search.go -in=tmp/tweets -strategy=substring
-#time go run golang/search.go -in=tmp/tweets -strategy=regex
-#time go run golang/search.go -in=../tmp/tweets/ -cpuprofile=regex.prof -strategy=regex
-#time go run golang/search.go -in=../tmp/tweets/ -cpuprofile=substring.prof -strategy=substring
+time golang/search -in=tmp/tweets -strategy=substring


### PR DESCRIPTION
This commit makes the end-to-end execution time for the Go example more
realistic in the sense that the vast majority of Go users will be using
a precompiled binary or something that they have compiled themselves
using `go get package/path` or `go install package/path` workflows.

In the original instrumentation case, the end-to-end execution time
included the compilation time of the benchmark.  Now, while compile
time may seem negligible, the Go project had been in the process of
converting its toolchain (compiler included) from C to being self-hosted
in Go itself.  New versions of Go use the new Go implementation, but the
implementation is a frankenstein of automated and by-hand C-to-Go
tooling:

http://gophercon.sourcegraph.com/post/83820197495/russ-cox-porting-the-go-compiler-from-c-to-go

The new compiler is feature-wise equivalent to its C predecessors, but
it is slow due to lack of design attention and housekeeping.  The Go
compiler is slated to become even slower with the 1.6 release due to
migrating the backend to a SSA-based one:

https://groups.google.com/forum/#!topic/golang-dev/vNboccLL95c

Post-1.6, it is expected that the compiler's throughput will have been
improved.  Further, the SSA backend enables the compiler to apply even
better optimization heuristics, which has the net effect of improving
the generated code.

Needless to say, let's not include the compile time in the
benchmark.  This shaves ca. 0.50-0.75s from the Go end-to-end rating.

As a side note, @dimroc, I would be happy to take ownership of the Go impl. if nobody else wants to.