### PR TITLE
add haskell implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ _testmain.go
 
 *.exe
 *.test
+.stack-work/
+dist
+dist-*

--- a/haskell/Makefile
+++ b/haskell/Makefile
@@ -1,0 +1,12 @@
+all: file
+
+file:
+	stack build
+	../run_haskell
+
+html:
+	bench 'stack exec haskell -- indice' --output indice.html
+	bench 'stack exec haskell -- regex' --output regex.html
+
+benchmark:
+	stack bench

--- a/haskell/Makefile
+++ b/haskell/Makefile
@@ -4,6 +4,9 @@ file:
 	stack build
 	../run_haskell
 
+memory:
+	stack exec haskell -- indice +RTS -s
+	stack exec haskell -- regex +RTS -s
 html:
 	bench 'stack exec haskell -- indice' --output indice.html
 	bench 'stack exec haskell -- regex' --output regex.html

--- a/haskell/Setup.hs
+++ b/haskell/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/haskell/bench/bench.hs
+++ b/haskell/bench/bench.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import Criterion.Main
+import qualified MapReduce as MR
+
+main = defaultMain [
+  bgroup "main"
+    [
+      bench "regex"  $ nfIO $ MR.runWith "regex"
+    , bench "indice" $ nfIO $ MR.runWith "indice"
+    ]
+  ]

--- a/haskell/benchmark.prof
+++ b/haskell/benchmark.prof
@@ -1,0 +1,13 @@
+benchmarking main/regex
+time                 7.652 s    (7.358 s .. 7.819 s)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 7.732 s    (7.710 s .. 7.744 s)
+std dev              19.57 ms   (0.0 s .. 21.07 ms)
+variance introduced by outliers: 19% (moderately inflated)
+
+benchmarking main/indice
+time                 2.887 s    (2.830 s .. 2.919 s)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 2.872 s    (2.856 s .. 2.881 s)
+std dev              14.19 ms   (0.0 s .. 15.57 ms)
+variance introduced by outliers: 19% (moderately inflated)

--- a/haskell/executable/Main.hs
+++ b/haskell/executable/Main.hs
@@ -1,0 +1,9 @@
+module Main where
+
+import qualified MapReduce
+import System.Environment
+
+-- will run the indice matcher if given no arguments
+main = do
+    [matcher] <- getArgs
+    MapReduce.runWith matcher

--- a/haskell/haskell.cabal
+++ b/haskell/haskell.cabal
@@ -40,7 +40,7 @@ library
 executable haskell
   hs-source-dirs:      executable
   main-is:             Main.hs
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
                      , haskell
   default-language:    Haskell2010

--- a/haskell/haskell.cabal
+++ b/haskell/haskell.cabal
@@ -1,0 +1,60 @@
+name:                haskell
+version:             0.1.0.0
+synopsis:            Initial project template from stack
+description:         Please see README.md
+homepage:            https://github.com/tippenein/haskell#readme
+license:             BSD3
+author:              tippenein
+maintainer:          tippenein@gmail.com
+copyright:           2016 Author name here
+category:            Web
+build-type:          Simple
+-- extra-source-files:
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:
+      MapReduce
+    , Matcher
+  build-depends:
+      base >= 4.7 && < 5
+    , pipes
+    , binary
+    , text
+    , regex-tdfa
+    , filepath
+    , Glob
+    , transformers
+    , containers
+    , async
+    , text
+    , stringsearch
+    , stm-containers
+    , list-t
+    , bytestring-lexing
+    , stm
+    , bytestring
+  default-language:    Haskell2010
+
+executable haskell
+  hs-source-dirs:      executable
+  main-is:             Main.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , haskell
+  default-language:    Haskell2010
+
+source-repository head
+  type:     git
+  location: https://github.com/tippenein/haskell
+
+benchmark benchmark
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      bench
+  main-is:             bench.hs
+  build-depends:       base >=4.6 && <4.9
+                     , haskell
+                     , criterion
+  default-language:    Haskell2010
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/haskell/src/MapReduce.hs
+++ b/haskell/src/MapReduce.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module MapReduce where
+
+import Matcher
+
+import Data.Foldable (traverse_)
+import System.FilePath.Glob (compile, globDir1)
+
+import qualified Control.Concurrent.Async as Async
+import qualified Control.Concurrent.STM as STM
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Lazy as ByteString.Lazy
+import qualified Data.ByteString.Lazy.Char8 as ByteString.Lazy.Char8
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified ListT
+import qualified STMContainers.Map as Map
+
+intToBs = T.encodeUtf8 . T.pack . show
+
+glue r (k, v) =
+    return (ByteString.concat
+            [ r
+            , ByteString.Lazy.Char8.toStrict k
+            , "\t"
+            , intToBs v
+            , "\n"
+            ])
+
+getMatcher :: String -> (ByteString.Lazy.ByteString -> Bool)
+getMatcher args =
+    case args of
+      "regex" -> regexMatch
+      "indice" -> indiceMatch
+      _ -> indiceMatch
+
+runWith :: String -> IO ()
+runWith matcherArg = do
+    files <- globDir1 (compile "tweets_*") "../tmp/tweets"
+
+    m <- Map.newIO
+
+    let matcher = getMatcher matcherArg
+    let increment key = STM.atomically (do
+            x <- Map.lookup key m
+            case x of
+                Nothing -> Map.insert 1 key m
+                Just n  -> n' `seq` Map.insert n' key m  where n' = n + 1 )
+
+    let processFile file = Async.Concurrently (do
+            bytes <- ByteString.Lazy.readFile file
+            traverse_ increment (parseFile matcher bytes) )
+
+    Async.runConcurrently (traverse_ processFile files)
+
+    fileContents <- STM.atomically (ListT.fold glue "" (Map.stream m))
+    ByteString.writeFile ("../tmp/haskell_" ++ matcherArg ++  "_results.txt") fileContents

--- a/haskell/src/Matcher.hs
+++ b/haskell/src/Matcher.hs
@@ -7,6 +7,7 @@ import qualified Data.ByteString.Lazy.Char8 as ByteString.Lazy.Char8
 import qualified Data.ByteString.Search as Search
 import qualified Text.Regex.TDFA.ByteString as Regex
 import Text.Regex.TDFA.Common
+import Data.Maybe (isJust)
 
 parseFile
     :: (ByteString.Lazy.ByteString -> Bool)
@@ -40,7 +41,7 @@ regexMatch :: ByteString.Lazy.ByteString -> Bool
 regexMatch bs =
     case regexMatch' bs of
       Left _ -> False
-      Right _ -> True
+      Right m -> isJust m
 
 regexMatch' =
       Regex.execute (regexPattern "knicks")

--- a/haskell/src/Matcher.hs
+++ b/haskell/src/Matcher.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Matcher where
+
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Lazy as ByteString.Lazy
+import qualified Data.ByteString.Lazy.Char8 as ByteString.Lazy.Char8
+import qualified Data.ByteString.Search as Search
+import qualified Text.Regex.TDFA.ByteString as Regex
+import Text.Regex.TDFA.Common
+
+parseFile
+    :: (ByteString.Lazy.ByteString -> Bool)
+    -> ByteString.Lazy.ByteString
+    -> [ByteString.Lazy.ByteString]
+parseFile matchFunction bytes0 =
+    [ neighborhood line
+    | line <- ByteString.Lazy.Char8.lines bytes0
+    , matchFunction line
+    ]
+  where
+    neighborhood =
+          ByteString.Lazy.takeWhile (/= 9)
+        . ByteString.Lazy.drop 1
+        . ByteString.Lazy.dropWhile (/= 9)
+
+regexPattern :: ByteString.ByteString -> Regex.Regex
+regexPattern bs = case Regex.compile comp ex bs of
+                    Left err -> error (show err)
+                    Right reg -> reg
+  where
+    comp = CompOption { caseSensitive = False
+                      , multiline = False
+                      , rightAssoc = True
+                      , newSyntax = False
+                      , lastStarGreedy = False
+                      } --defaultCompOpt { caseSensitive = False }
+    ex = ExecOption { captureGroups = False}
+
+regexMatch :: ByteString.Lazy.ByteString -> Bool
+regexMatch bs =
+    case regexMatch' bs of
+      Left _ -> False
+      Right _ -> True
+
+regexMatch' =
+      Regex.execute (regexPattern "knicks")
+    . ByteString.Lazy.toStrict
+
+indiceMatch :: ByteString.Lazy.ByteString -> Bool
+indiceMatch =
+      not
+    . null
+    . Search.indices "knicks"
+    . ByteString.map lower
+    . ByteString.Lazy.toStrict
+
+  where
+    lower w8 = if 65 <= w8 && w8 < 91 then w8 + 32 else w8

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -1,0 +1,12 @@
+resolver: lts-5.18
+
+packages:
+- '.'
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []

--- a/run_haskell
+++ b/run_haskell
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cd haskell && stack build
+
+export TIMEFORMAT=%R
+# time stack exec haskell -- +RTS -N4
+function runIt() {
+  time stack exec haskell -- $1
+}
+
+case "$1" in
+"indice")
+  echo 'Start indice run'
+  runIt "indice"
+  ;;
+"regex")
+  echo 'Start regex run'
+  runIt "regex"
+  ;;
+*)
+  echo 'Start indice run'
+  runIt "indice"
+  echo 'Start regex run'
+  runIt "regex"
+  ;;
+esac


### PR DESCRIPTION
Adds 2 implementations
1. using a bytestring indice search
2. with regex (regex-tdfa)

The results are included in `benchmark.prof` and on my machine are:
`regex - 7.652 s    (7.358 s .. 7.819 s)`
`indice - 2.887 s    (2.830 s .. 2.919 s)`

The Makefile includes the commands needed to run these benchmarks yourself. (`make benchmark`)

Thanks to @Gabriel439 for the majority of this implementation - [here](https://www.reddit.com/r/haskell/comments/4lhydt/rfc_improving_speed_of_a_map_reduce_using_pipes/d3oettx)

edit: Added `memory` command to makefile to show memory usage.
indice: 28 MB total memory in use 
regex: 9 MB total memory in use 
